### PR TITLE
Update GencodeOptions.java for CUDA 7.5

### DIFF
--- a/src/org/trifort/rootbeer/generate/opencl/tweaks/GencodeOptions.java
+++ b/src/org/trifort/rootbeer/generate/opencl/tweaks/GencodeOptions.java
@@ -23,8 +23,8 @@ public class GencodeOptions {
   }
   
   public enum ComputeCapability {
-    ALL, SM_11, SM_12, SM_20, SM_21, SM_30, SM_35;
-  }
+      ALL, SM_11, SM_12, SM_20, SM_21, SM_30, SM_35, SM_50, SM_52, SM_53;
+    }
   
   private boolean versionMatches(String versionString, String version){
     return versionString.contains("release "+version);
@@ -32,6 +32,9 @@ public class GencodeOptions {
   
   public String getOptions(){
     String version = getVersion();
+    String sm_53;
+    String sm_52;
+    String sm_50;
     String sm_35;
     String sm_30;
     String sm_21;
@@ -39,6 +42,9 @@ public class GencodeOptions {
     String sm_12;
     String sm_11;
     if(File.separator.equals("/")){
+      sm_53 = "--generate-code arch=compute_53,code=\"sm_53,compute_53\" ";
+      sm_52 = "--generate-code arch=compute_52,code=\"sm_52,compute_52\" ";
+      sm_50 = "--generate-code arch=compute_50,code=\"sm_50,compute_50\" ";
       sm_35 = "--generate-code arch=compute_35,code=\"sm_35,compute_35\" ";
       sm_30 = "--generate-code arch=compute_30,code=\"sm_30,compute_30\" ";
       sm_21 = "--generate-code arch=compute_20,code=\"sm_21,compute_20\" ";
@@ -46,6 +52,9 @@ public class GencodeOptions {
       sm_12 = "--generate-code arch=compute_12,code=\"sm_12,compute_12\" ";
       sm_11 = "--generate-code arch=compute_11,code=\"sm_11,compute_11\" ";
     } else {
+      sm_53 = "--generate-code arch=compute_53,code=\"sm_53\" ";
+      sm_52 = "--generate-code arch=compute_52,code=\"sm_52\" ";
+      sm_50 = "--generate-code arch=compute_50,code=\"sm_50\" ";
       sm_35 = "--generate-code arch=compute_35,code=\"sm_35\" ";
       sm_30 = "--generate-code arch=compute_30,code=\"sm_30\" ";
       sm_21 = "--generate-code arch=compute_20,code=\"sm_21\" ";
@@ -66,7 +75,28 @@ public class GencodeOptions {
       sm_11 = "";
     }
     
-    if(versionMatches(version, "7.0") ||
+    if(versionMatches(version, "7.5")) {
+      switch (Configuration.compilerInstance().getComputeCapability()) {
+        case ALL:
+          return sm_53 + sm_52 + sm_50 + sm_35 + sm_30 + sm_21 + sm_20;
+        case SM_20:
+          return sm_20;
+        case SM_21:
+          return sm_21;
+        case SM_30:
+          return sm_30;
+        case SM_35:
+          return sm_35;
+        case SM_50:
+          return sm_50;
+        case SM_52:
+          return sm_52;
+        case SM_53:
+          return sm_53;
+	default:
+	  return sm_53 + sm_52 + sm_50 + sm_35 + sm_30 + sm_21 + sm_20;
+      }
+    } else if(versionMatches(version, "7.0") ||
        versionMatches(version, "6.5") ||
        versionMatches(version, "6.0") ||
        versionMatches(version, "5.5") ||


### PR DESCRIPTION
Added compute capability SM_50, SM_52 & SM_53 (no support for SM_60 & SM_61)
Created v7.5 section without support for SM_11 & SM_12 as they are finally deprecated